### PR TITLE
fix: set a blank default date for new promotionals

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -47,7 +47,7 @@
                         </div>
                         <div class="modal-body">
                             <div class="form-group">
-                                <label>Date</label>&nbsp;<input type="date" value="2011-09-29" class="form-control" name="promotionalDate"><br>
+                                <label>Date</label>&nbsp;<input type="date" class="form-control" name="promotionalDate"><br>
                             </div>
                             <div class="form-group">
                                 <label>Type</label>


### PR DESCRIPTION
Changed the default date when adding a new promotional to the placeholder "mm/dd/yyyy".