### PR TITLE
fix: set add promotional default date to current date

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -35,7 +35,7 @@
                         </div>
                         <div class="modal-body">
                             <div class="form-group">
-                                <label>Date</label>&nbsp;<input type="date" min="{{ date.today() }}" class="form-control" name="promotionalDate"><br>
+                                <label>Date</label>&nbsp;<input type="date" min="{{ date.today() }}" value="{{ date.today() }}" class="form-control" name="promotionalDate"><br>
                             </div>
                             <div class="form-group">
                                 <label>Type</label>


### PR DESCRIPTION
Add promotional now has a default date set to the current date.